### PR TITLE
mimic make clean

### DIFF
--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -120,15 +120,10 @@ def devbuildcosmo(self, args):
     # Clean if needed
     if args.clean_build:
         print("\033[92m" + "==> " + "\033[0m" + "cosmo: Cleaning build directory")
-        files_to_clean = []
 
-        # make clean, but without make command
-        files_to_clean.extend(glob.glob(source_path + "/cosmo/ACC/.depend*"))
-        files_to_clean.extend(glob.glob(source_path + "/cosmo/ACC/obj/*"))
-        files_to_clean.extend(glob.glob(source_path + "/cosmo/ACC/claw/*"))
-        for file in files_to_clean:
-            if os.path.isfile(file):
-                os.remove(file)
+        # set F90 to prevent abort defined in Makefile
+        os.environ["F90"] = "NOTSET"
+        subprocess.run(["make", "clean"], cwd=source_path + "/cosmo/ACC")
 
         if os.path.exists(source_path + "/spack-build"):
             print("\033[92m" + "==> " + "\033[0m" + "dycore: Cleaning build directory")

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -7,6 +7,7 @@ import sys
 import os
 import subprocess
 import shutil
+import glob
 
 import llnl.util.tty as tty
 import re
@@ -119,9 +120,17 @@ def devbuildcosmo(self, args):
     # Clean if needed
     if args.clean_build:
         print("\033[92m" + "==> " + "\033[0m" + "cosmo: Cleaning build directory")
-        subprocess.run(["make", "clean"], cwd=source_path + "/cosmo/ACC")
+        files_to_clean = []
 
-        if os.path.exists(base_directory + "/spack-build"):
+        # make clean, but without make command
+        files_to_clean.extend(glob.glob(source_path + "/cosmo/ACC/.depend*"))
+        files_to_clean.extend(glob.glob(source_path + "/cosmo/ACC/obj/*"))
+        files_to_clean.extend(glob.glob(source_path + "/cosmo/ACC/claw/*"))
+        for file in files_to_clean:
+            if os.path.isfile(file):
+                os.remove(file)
+
+        if os.path.exists(source_path + "/spack-build"):
             print("\033[92m" + "==> " + "\033[0m" + "dycore: Cleaning build directory")
             shutil.rmtree(source_path + "/spack-build")
 

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -124,6 +124,7 @@ def devbuildcosmo(self, args):
         # set F90 to prevent abort defined in Makefile
         os.environ["F90"] = "NOTSET"
         subprocess.run(["make", "clean"], cwd=source_path + "/cosmo/ACC")
+        os.environ.pop("F90")
 
         if os.path.exists(source_path + "/spack-build"):
             print("\033[92m" + "==> " + "\033[0m" + "dycore: Cleaning build directory")


### PR DESCRIPTION
Hi @Stagno 
The -c option did not work properly in all cases, also the spack-build removal used an unset variable.

This PR should fix both.